### PR TITLE
update the user-agent for cheating the server

### DIFF
--- a/src/canrevan/__init__.py
+++ b/src/canrevan/__init__.py
@@ -12,7 +12,7 @@ def _main():
     # Create a crawler for collecting article urls and news contents.
     crawler = Crawler(concurrent_tasks=args.max_jobs,
                       num_parsing_processes=args.num_cores,
-                      request_headers={'user-agent': 'canrevan'},
+                      request_headers={'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'},
                       request_timeout=args.timeout)
 
     # Collect article urls from navigation pages.


### PR DESCRIPTION
### 이슈
- 기존 canrevan 3.1.1 버전에서 아래와 같이 articles urls를 수집하는 과정에서 article을 수집하지 못하여 아래와 같이 에러가 발생했습니다.
<img width="1435" alt="스크린샷 2021-01-29 오전 1 05 50" src="https://user-images.githubusercontent.com/38907104/106168169-53632e00-61d1-11eb-8e5d-3e3e7343cc48.png">

### 해결
- 기존 작성하셨던 header의 `{'user-agent': 'canrevan'}`가 서버에 의해서 크롤러로 감지가 되어서 block을 먹은 것 같습니다.
- 아래와 같이 header의 user-agent의 값을 바꿔주니 문제가 해결되었습니다.
```
{'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'}
```

<img width="1433" alt="스크린샷 2021-01-29 오전 1 34 05" src="https://user-images.githubusercontent.com/38907104/106168879-1d727980-61d2-11eb-8981-4daf94768be8.png">
